### PR TITLE
disallow token in header AND body/query as stated in draft.

### DIFF
--- a/lib/passport-http-bearer/strategy.js
+++ b/lib/passport-http-bearer/strategy.js
@@ -87,10 +87,14 @@ Strategy.prototype.authenticate = function(req) {
       return this.fail(400);
     }
   }
-  else if (req.body && req.body['access_token']) {
+
+  if (req.body && req.body['access_token']) {
+    if(token) return this.fail(400);
     token = req.body['access_token'];
   }
-  else if (req.query && req.query['access_token']) {
+
+  if (req.query && req.query['access_token']) {
+    if(token) return this.fail(400);
     token = req.query['access_token'];
   }
   

--- a/test/strategy-test.js
+++ b/test/strategy-test.js
@@ -48,7 +48,7 @@ vows.describe('BearerStrategy').addBatch({
       },
       'should authenticate' : function(err, user) {
         assert.equal(user.token, 'vF9dft4qmT');
-      },
+      }
     },
   },
   
@@ -608,5 +608,31 @@ vows.describe('BearerStrategy').addBatch({
       assert.throws(function() { new BearerStrategy() });
     },
   },
+  'strategy getting token via multiple methods': {
+    topic: function() {
+      var strategy = new BearerStrategy({ scope: ['email', 'feed'] },function(token, done) {
+        assert.ok(false);
+      });
+      var self = this;
+      var req = {};
+      req.headers = {};
+      req.headers.authorization = 'BEARER vF9dft4qmT';
+      req.query = {};
+      req.query.access_token = "vF9dft4qmT";
+      strategy.success = function(user) {
+        self.callback(new Error("should not be called"));
+      };
+      strategy.fail = function(challenge) {
+        self.callback(null, challenge);
+      }
+      process.nextTick(function() {
+        strategy.authenticate(req);
+      });
+     },
+    'should fail authentication with error 400': function(err, status) {
+      assert.isNull(err);
+      assert.equal(status, 400);
+    }
+  }
   
 }).export(module);


### PR DESCRIPTION
Conform to bearer token draft by disallowing the token to be suplied via multiple methods as specified in 2. and 3.1
