### PR TITLE
Add the option for per Authentication options

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -125,7 +125,7 @@ Strategy.prototype.authenticate = function(req, options) {
         info = { message: info }
       }
       info = info || {};
-      return self.fail(self._challenge(null, null, 'invalid_token', info.message));
+      return self.fail(self._challenge(options.realm, options.scope, 'invalid_token', info.message));
     }
     self.success(user, info);
   }

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -83,9 +83,13 @@ util.inherits(Strategy, passport.Strategy);
  * @param {Object} req
  * @api protected
  */
-Strategy.prototype.authenticate = function(req) {
+Strategy.prototype.authenticate = function(req, options) {
   var token;
-  
+
+  if(options.scope) {
+    options.scope = (Array.isArray(options.scope)) ? options.scope : [ options.scope ]; 
+  }
+
   if (req.headers && req.headers.authorization) {
     var parts = req.headers.authorization.split(' ');
     if (parts.length == 2) {
@@ -110,7 +114,7 @@ Strategy.prototype.authenticate = function(req) {
     token = req.query.access_token;
   }
   
-  if (!token) { return this.fail(this._challenge()); }
+  if (!token) { return this.fail(this._challenge(options.realm, options.scope)); }
   
   var self = this;
   
@@ -121,7 +125,7 @@ Strategy.prototype.authenticate = function(req) {
         info = { message: info }
       }
       info = info || {};
-      return self.fail(self._challenge('invalid_token', info.message));
+      return self.fail(self._challenge(null, null, 'invalid_token', info.message));
     }
     self.success(user, info);
   }
@@ -138,9 +142,17 @@ Strategy.prototype.authenticate = function(req) {
  *
  * @api private
  */
-Strategy.prototype._challenge = function(code, desc, uri) {
-  var challenge = 'Bearer realm="' + this._realm + '"';
-  if (this._scope) {
+Strategy.prototype._challenge = function(realm, scope, code, desc, uri) {
+  var challenge = 'Bearer realm="';
+
+  if(realm) {
+    challenge += realm + '"';
+  } else if(this._realm) {
+    challenge += this._realm + '"';
+  }
+  if(scope) {
+    challenge += ', scope="' + scope.join(' ') + '"';
+  } else if (this._scope) {
     challenge += ', scope="' + this._scope.join(' ') + '"';
   }
   if (code) {

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -89,8 +89,12 @@ Strategy.prototype.authenticate = function(req, options) {
   var scope;
 
   if(options) {
-    realm = options.realm;
-    scope = (Array.isArray(options.scope)) ? options.scope : [ options.scope ]; 
+    if(options.realm) {
+    	realm = options.realm;
+    }
+    if(options.scope) {
+    	scope = (Array.isArray(options.scope)) ? options.scope : [ options.scope ];
+    }	
   }
 
   if (req.headers && req.headers.authorization) {

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -85,9 +85,12 @@ util.inherits(Strategy, passport.Strategy);
  */
 Strategy.prototype.authenticate = function(req, options) {
   var token;
+  var realm;
+  var scope;
 
-  if(options.scope) {
-    options.scope = (Array.isArray(options.scope)) ? options.scope : [ options.scope ]; 
+  if(options) {
+    realm = options.realm;
+    scope = (Array.isArray(options.scope)) ? options.scope : [ options.scope ]; 
   }
 
   if (req.headers && req.headers.authorization) {
@@ -114,7 +117,7 @@ Strategy.prototype.authenticate = function(req, options) {
     token = req.query.access_token;
   }
   
-  if (!token) { return this.fail(this._challenge(options.realm, options.scope)); }
+  if (!token) { return this.fail(this._challenge(realm, scope)); }
   
   var self = this;
   
@@ -125,7 +128,7 @@ Strategy.prototype.authenticate = function(req, options) {
         info = { message: info }
       }
       info = info || {};
-      return self.fail(self._challenge(options.realm, options.scope, 'invalid_token', info.message));
+      return self.fail(self._challenge(realm, scope, 'invalid_token', info.message));
     }
     self.success(user, info);
   }


### PR DESCRIPTION
With these two commits you can set per authentication options. As the only two options being realm and scope I find this extremely useful. For example if you had a rest API and the realm of the endpoint is something different than every other endpoint there is currently no way to configure that. With this patch you could do this:

    passport.authenticate('bearer', {session: false, realm: 'Admin'});

If no options are found it defaults back to the options set when the strategy was created otherwise it just uses Users as the realm and no scope. Nothing has changed there.

If you have any feedback that would be great!