### PR TITLE
Pass tokens that are not related to users

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -116,7 +116,7 @@ Strategy.prototype.authenticate = function(req) {
   
   function verified(err, user, info) {
     if (err) { return self.error(err); }
-    if (!user) {
+    if (user === false) {
       if (typeof info == 'string') {
         info = { message: info }
       }


### PR DESCRIPTION
Hej,

all your examples recommend to pass `false` if the authentication fails.

I think this should be valid, if there is no user related to the token (e.g. the token was issued using client_credentials).

Cheers
Niko