### PR TITLE
Add optional authentication option (Fixes #38)

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -81,10 +81,13 @@ util.inherits(Strategy, passport.Strategy);
  * header, body parameter, or query parameter.
  *
  * @param {Object} req
+ * @param {Object} options
  * @api protected
  */
-Strategy.prototype.authenticate = function(req) {
+Strategy.prototype.authenticate = function(req, options) {
   var token;
+
+  options = options || {};
   
   if (req.headers && req.headers.authorization) {
     var parts = req.headers.authorization.split(' ');
@@ -110,7 +113,10 @@ Strategy.prototype.authenticate = function(req) {
     token = req.query.access_token;
   }
   
-  if (!token) { return this.fail(this._challenge()); }
+  if (!token) {
+    if (options.optional) { return this.pass(); }
+    return this.fail(this._challenge());
+  }
   
   var self = this;
   


### PR DESCRIPTION
This PR adds an optional configuration key that enables API endpoints to process unauthenticated requests. (Fixes #38)

Example in CoffeeScript:

```coffeescript
router.get '/news/feed', 
  passport.authenticate('bearer', { session: false, optional: true }),
  (req, res) ->
    if req.user
      res.json personalizedFeed(req.user)
    else
      res.json publicFeed()
    return
```