### PR TITLE
Small typo in the first paragraph of the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ HTTP Bearer authentication strategy for [Passport](http://passportjs.org/).
 
 This module lets you authenticate HTTP requests using bearer tokens, as
 specified by [RFC 6750](http://tools.ietf.org/html/rfc6750), in your Node.js
-applications.  Bearer tokens are typically used protect API endpoints, and are
+applications.  Bearer tokens are typically used to protect API endpoints, and are
 often issued using OAuth 2.0.
 
 By plugging into Passport, bearer token support can be easily and unobtrusively


### PR DESCRIPTION
Corrected first paragraph to read:

> "Bearer tokens are typically used **to** protect API endpoints ..."