### PR TITLE
not to rewrite token if we already have it

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -60,7 +60,7 @@ function Strategy(options, verify) {
     options = {};
   }
   if (!verify) { throw new TypeError('HTTPBearerStrategy requires a verify callback'); }
-  
+
   passport.Strategy.call(this);
   this.name = 'bearer';
   this._verify = verify;
@@ -85,13 +85,13 @@ util.inherits(Strategy, passport.Strategy);
  */
 Strategy.prototype.authenticate = function(req) {
   var token;
-  
+
   if (req.headers && req.headers.authorization) {
     var parts = req.headers.authorization.split(' ');
     if (parts.length == 2) {
       var scheme = parts[0]
         , credentials = parts[1];
-        
+
       if (/^Bearer$/i.test(scheme)) {
         token = credentials;
       }
@@ -100,20 +100,20 @@ Strategy.prototype.authenticate = function(req) {
     }
   }
 
-  if (req.body && req.body.access_token) {
+  if (!token && req.body && req.body.access_token) {
     if (token) { return this.fail(400); }
     token = req.body.access_token;
   }
 
-  if (req.query && req.query.access_token) {
+  if (!token && req.query && req.query.access_token) {
     if (token) { return this.fail(400); }
     token = req.query.access_token;
   }
-  
+
   if (!token) { return this.fail(this._challenge()); }
-  
+
   var self = this;
-  
+
   function verified(err, user, info) {
     if (err) { return self.error(err); }
     if (!user) {
@@ -125,7 +125,7 @@ Strategy.prototype.authenticate = function(req) {
     }
     self.success(user, info);
   }
-  
+
   if (self._passReqToCallback) {
     this._verify(req, token, verified);
   } else {
@@ -152,7 +152,7 @@ Strategy.prototype._challenge = function(code, desc, uri) {
   if (uri && uri.length) {
     challenge += ', error_uri="' + uri + '"';
   }
-  
+
   return challenge;
 };
 


### PR DESCRIPTION
I have situation where body have `access_token` field, that not related to bearer token that is set through header