### PR TITLE
allowNoToken option implemented, with tests

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -60,7 +60,7 @@ function Strategy(options, verify) {
     options = {};
   }
   if (!verify) { throw new TypeError('HTTPBearerStrategy requires a verify callback'); }
-  
+
   passport.Strategy.call(this);
   this.name = 'bearer';
   this._verify = verify;
@@ -69,6 +69,7 @@ function Strategy(options, verify) {
     this._scope = (Array.isArray(options.scope)) ? options.scope : [ options.scope ];
   }
   this._passReqToCallback = options.passReqToCallback;
+  this._allowNoToken = options.allowNoToken || false;
 }
 
 /**
@@ -85,13 +86,13 @@ util.inherits(Strategy, passport.Strategy);
  */
 Strategy.prototype.authenticate = function(req) {
   var token;
-  
+
   if (req.headers && req.headers.authorization) {
     var parts = req.headers.authorization.split(' ');
     if (parts.length == 2) {
       var scheme = parts[0]
         , credentials = parts[1];
-        
+
       if (/^Bearer$/i.test(scheme)) {
         token = credentials;
       }
@@ -109,11 +110,11 @@ Strategy.prototype.authenticate = function(req) {
     if (token) { return this.fail(400); }
     token = req.query.access_token;
   }
-  
-  if (!token) { return this.fail(this._challenge()); }
-  
+
+  if (!token && !this._allowNoToken) { return this.fail(this._challenge()); }
+
   var self = this;
-  
+
   function verified(err, user, info) {
     if (err) { return self.error(err); }
     if (!user) {
@@ -125,7 +126,7 @@ Strategy.prototype.authenticate = function(req) {
     }
     self.success(user, info);
   }
-  
+
   if (self._passReqToCallback) {
     this._verify(req, token, verified);
   } else {
@@ -152,7 +153,7 @@ Strategy.prototype._challenge = function(code, desc, uri) {
   if (uri && uri.length) {
     challenge += ', error_uri="' + uri + '"';
   }
-  
+
   return challenge;
 };
 

--- a/test/strategy.options.test.js
+++ b/test/strategy.options.test.js
@@ -3,18 +3,18 @@ var chai = require('chai')
 
 
 describe('Strategy', function() {
-    
+
   describe('with realm option', function() {
     var strategy = new Strategy({ realm: 'Administrators' }, function(token, done) {
-      if (token == 'vF9dft4qmT') { 
+      if (token == 'vF9dft4qmT') {
         return done(null, { id: '1234' }, { scope: 'read' });
       }
       return done(null, false);
     });
-  
+
     describe('handling a request without credentials', function() {
       var challenge;
-    
+
       before(function(done) {
         chai.passport(strategy)
           .fail(function(c) {
@@ -25,25 +25,25 @@ describe('Strategy', function() {
           })
           .authenticate();
       });
-    
+
       it('should fail with challenge', function() {
         expect(challenge).to.be.a.string;
         expect(challenge).to.equal('Bearer realm="Administrators"');
       });
     });
   });
-  
+
   describe('strategy with scope option', function() {
     var strategy = new Strategy({ scope: 'email' }, function(token, done) {
-      if (token == 'vF9dft4qmT') { 
+      if (token == 'vF9dft4qmT') {
         return done(null, { id: '1234' }, { scope: 'read' });
       }
       return done(null, false);
     });
-  
+
     describe('handling a request without credentials', function() {
       var challenge;
-    
+
       before(function(done) {
         chai.passport(strategy)
           .fail(function(c) {
@@ -54,25 +54,25 @@ describe('Strategy', function() {
           })
           .authenticate();
       });
-    
+
       it('should fail with challenge', function() {
         expect(challenge).to.be.a.string;
         expect(challenge).to.equal('Bearer realm="Users", scope="email"');
       });
     });
   });
-  
+
   describe('strategy with scope option set to array', function() {
     var strategy = new Strategy({ scope: ['email', 'feed'] }, function(token, done) {
-      if (token == 'vF9dft4qmT') { 
+      if (token == 'vF9dft4qmT') {
         return done(null, { id: '1234' }, { scope: 'read' });
       }
       return done(null, false);
     });
-  
+
     describe('handling a request without credentials', function() {
       var challenge;
-    
+
       before(function(done) {
         chai.passport(strategy)
           .fail(function(c) {
@@ -83,12 +83,59 @@ describe('Strategy', function() {
           })
           .authenticate();
       });
-    
+
       it('should fail with challenge', function() {
         expect(challenge).to.be.a.string;
         expect(challenge).to.equal('Bearer realm="Users", scope="email feed"');
       });
     });
   });
-  
+
+  describe('strategy with allow no token option', function() {
+    var strategy = new Strategy({ allowNoToken: true }, function(token, done) {
+      if (token == 'vF9dft4qmT') {
+        return done(null, { id: '1234' });
+      }
+      return done(null, {});
+    });
+
+    describe('handling a request with token in header', function() {
+      var user;
+
+      before(function(done) {
+        chai.passport(strategy)
+          .success(function(u) {
+            user = u;
+            done();
+          })
+          .req(function(req) {
+            req.headers.authorization = 'Bearer vF9dft4qmT';
+          })
+          .authenticate();
+      });
+
+      it('should supply user', function() {
+        expect(user).to.be.an.object;
+        expect(user.id).to.equal('1234');
+      });
+    });
+
+    describe('handling a request without token', function() {
+      var user;
+
+      before(function(done) {
+        chai.passport(strategy)
+          .success(function(u) {
+            user = u;
+            done();
+          })
+          .authenticate();
+      });
+
+      it('should supply empty user', function() {
+        expect(user).to.be.an.object;
+        expect(user).to.be.empty();
+      });
+    });
+  });
 });


### PR DESCRIPTION
Implement an option to allow that, when no token is sent, the verify callback is called nonetheless.

This will allow the implementation of _free for all_ API endpoints, mixed with restricted ones. Authorization is a different beast altogether, and should be handled next to the business logic anyway.

My concrete concern was with a GraphQL API, where I can't divide authenticated and unauthenticated queries and mutations, it's all in the same schema, and the authorization is inside the resolvers; but I still wanted to use passport-http-bearer as a middleware before the (Apollo) GraphQL - which would have force me to provide a token in every call, even unrestricted ones.